### PR TITLE
Adjusted required php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/pimlie/php-unit-conversion"
     },
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "myclabs/php-enum": "^1.5"
     },
     "require-dev": {


### PR DESCRIPTION
According to [this page](http://php.net/manual/en/language.oop5.constants.php) from the PHP manual, the `::class` constant was introduced in PHP 5.5 which should therefore be the required minimum version. That constant is used throughout the project, at least [here](https://github.com/pimlie/php-unit-conversion/blob/7ea88fdeb7218a4785fbb99b94e97f8d63c934c9/src/Unit.php#L281)

> The special ::class constant is available as of PHP 5.5.0, and allows for fully qualified class name resolution at compile time, this is useful for namespaced classes: