### PR TITLE
Increased required php version to 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/pimlie/php-unit-conversion"
     },
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.0",
         "myclabs/php-enum": "^1.5"
     },
     "require-dev": {


### PR DESCRIPTION
Constant expressions are available as of php 5.6 (see [changelog](http://php.net/manual/en/migration56.new-features.php)). They are used in e.g. src/Unit/Volume/AcreFoot.php