### PR TITLE
fix: Unit format should not force two digits when precision = 0

### DIFF
--- a/src/Unit.php
+++ b/src/Unit.php
@@ -434,7 +434,7 @@ class Unit
      */
     public function format($precision = 3, $addSymbol = true)
     {
-        $format = '%02.' . $precision . 'f';
+        $format = '%.' . $precision . 'f';
 
         if (!$addSymbol) {
             return sprintf($format, $this->getValue());


### PR DESCRIPTION
## Description
This pr is just to remove the forced two digits when we set the precision to 0 on a format. 
This does not break anything, all unit tests are ok.