### PR TITLE
Base Unit class implements JsonSerializable now

### DIFF
--- a/src/Unit.php
+++ b/src/Unit.php
@@ -1,13 +1,14 @@
 <?php
 namespace PhpUnitConversion;
 
+use JsonSerializable;
 use InvalidArgumentException;
 use PhpUnitConversion\Map as UnitMap;
 use PhpUnitConversion\Exception\InvocationException;
 use PhpUnitConversion\Exception\UnsupportedUnitException;
 use PhpUnitConversion\Exception\UnsupportedConversionException;
 
-class Unit
+class Unit implements JsonSerializable
 {
     /** @var float */
     protected $value;
@@ -466,5 +467,17 @@ class Unit
     {
         $symbol = $this->getSymbol();
         return (string)$this->getValue() . ($symbol ? ' ' . $symbol : '');
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'value' => $this->getValue(),
+            'symbol' => $this->getSymbol(),
+            'label' => $this->getLabel(),
+        ];
     }
 }

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -108,6 +108,20 @@ class UnitTest extends TestCase
         $this->assertEquals('1 u', (string)$unit);
     }
 
+    public function testToJson()
+    {
+        $unit = new MyUnitType\OneUnit(1);
+
+        $expected = [
+            'value' => 1,
+            'symbol' => 'u',
+            'label' => 'unit',
+        ];
+
+        $this->assertEquals($expected, $unit->jsonSerialize());
+        $this->assertEquals(json_encode($expected), json_encode($unit));
+    }
+
     public function testInvalidInvocation()
     {
         $this->expectException(Exception::class);


### PR DESCRIPTION
I'm using this library in a Laravel project where I cast various values to units to be able to easily convert them. The admin area is built with Filament/Livewire. Livewire validates the current request data by creating a JSON fingerprint from it. Somehow a unit is occasionally encoded as `{}` or as `[]` in this fingerprint, causing a mismatch and an error.  My changes fixes this. 

My particular use case here sounds a bit weird tbh, but being able to encode a unit as JSON could be quite useful in other areas, like API responses for example. Anyways, I'd appreciate it if you could merge these changes. Cheers!